### PR TITLE
Update SvelteKit docs to reflect latest version

### DIFF
--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -82,9 +82,7 @@ export interface SvelteKitPWAOptions extends Partial<VitePWAOptions> {
 
 ## SvelteKit Pages
 
-If you want your application to work offline, you should ensure you have not set `hydrate: false` on any of your pages since it will prevent injecting JavaScript into the layout for offline support.
-
-Unlike the [SvelteKit service worker module](https://kit.svelte.dev/docs#modules-$service-worker), the `vite-plugin-pwa` plugin will allow you to test your webmanifest and custom service worker in dev, check the [Development section](/guide/development) for more details.
+If you want your application to work offline, you should ensure you have not set `csr: false` on any of your pages since it will prevent injecting JavaScript into the layout for offline support.
 
 ### Auto Update
 


### PR DESCRIPTION
`hydrate` no longer exists and SvelteKit's service worker now works in dev mode. SvelteKit's dev-mode support only works in Chrome though - I'm not sure if there's any restriction like that in the PWA plugin? If not, we could add back that sentence with the additional clarification