### PR TITLE
fix: hydration error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,18 +6,6 @@ import NavbarFix from './plugins/navbar'
 
 export default defineConfig({
   logLevel: 'info',
-  ssr: {
-    format: 'cjs',
-  },
-  legacy: {
-    buildSsrCjsExternalHeuristics: true,
-  },
-  build: {
-    // sourcemap: true,
-    // minify: false,
-    ssrManifest: false,
-    manifest: false,
-  },
   optimizeDeps: {
     exclude: [
       '@vueuse/core',


### PR DESCRIPTION
Updating to Vite 4 and refreshing any page breaks page or partial page content with `Hydration completed but contains mismatches` error.