### PR TITLE
NGINX: Load default system mime types

### DIFF
--- a/deployment/nginx.md
+++ b/deployment/nginx.md
@@ -21,6 +21,7 @@ or any `http`, `server` or location `location` block with
 
 
 ```nginx
+include mime.types;
 types {
   application/manifest+json  webmanifest;
 }


### PR DESCRIPTION
Without the `include mime.types;` directive within the `server` block `types` overrides system ones and in effect all files except `.webmanifest` are served with `Content-Type: application/octet-stream`.

See this [SO answer](https://stackoverflow.com/a/37330325/1012616) for more details