### PR TITLE
docs: Updates inject-manifest docs to explicitly mention devOptions

### DIFF
--- a/guide/inject-manifest.md
+++ b/guide/inject-manifest.md
@@ -42,6 +42,10 @@ VitePWA({
 })
 ```
 
+### Development
+
+If you would like the service worker to run in development, make sure to enable it in the [devOptions](/guide/development#plugin-configuration) and to set the type to [module](/guide/development#injectmanifest-strategy) if required.
+
 ### Service Worker Code
 
 Your custom service worker (`public/sw.js`) should have at least this code (you also need to install `workbox-precaching` as `dev dependency` to your project):


### PR DESCRIPTION
Just a small docs update to hopefully save someone a lot of pain.

Whilst following the docs for injecting a custom service worker I kept running into the `Cannot use import statement outside a module` error. After spending a long time on it, I eventually found that it's 100% answered in the docs already, so I'm just making that more clear.

I think this could be a pretty common use case, a user is developing a custom service worker, they're reading the custom service worker docs and they're copying the code samples with imports in them, so hopefully this is useful.

Cheers