### PR TITLE
Remove cache directive for workbox-* files

### DIFF
--- a/deployment/nginx.md
+++ b/deployment/nginx.md
@@ -72,13 +72,6 @@ location ^~ /assets/ {
     try_files $uri =404;
 }
 
-# all workbox scripts are compiled with hash in filename, cache forever
-location ^~ /workbox- {
-    add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
-    ...
-    try_files $uri =404;
-}
-
 # assume that everything else is handled by the application router, by injecting the index.html.
 location / {
     autoindex off;


### PR DESCRIPTION
The `workbox-window.prod.es5.[HASH].js` file is being generated by vite inside `assets` directory, There are no files generated matching above glob in dist directory.

There is no need for special cache directive, caching is already covered by ` location ^~ /assets/` block.