### PR TITLE
docs: include new SvelteKit options

### DIFF
--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -19,7 +19,7 @@ For `Type declarations`, `Prompt for update` and `Periodic SW Updates` go to [Sv
 :::
 
 ::: tip
-If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
+If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/service-workers) to disable it on your application.
 :::
 
 ## Generate Custom Service Worker

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -5,9 +5,9 @@ title: SvelteKit | Frameworks
 # SvelteKit
 
 ::: warning
-From version `^0.2.0`, `SvelteKitPWA` plugin will assume you're using latest `SvelteKit`.
+From version `v0.2.0`, `SvelteKitPWA` plugin requires SvelteKit 1.3.1+.
 
-If you're using old `SvelteKit` versions between `1.0.*` and `1.3.0`, you should use old `0.1.*` `SvelteKitPWA` plugin version.
+If you're using old `SvelteKit` version previous to `v1.3.1`, you should use old `0.1.*` `SvelteKitPWA` plugin version.
 :::
 
 ::: tip

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -35,6 +35,8 @@ const config = {
     }
   }
 };
+
+export default config;
 ```
 
 Then in your Vite config file:

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -19,7 +19,34 @@ For `Type declarations`, `Prompt for update` and `Periodic SW Updates` go to [Sv
 :::
 
 ::: tip
-You should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
+If you're using an old `SvelteKit` version from `1.0.*` to `1.3.2`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
+
+From version `0.1.4`, `SvelteKitPWA` plugin will delegate the service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
+You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
+```ts
+// svelte.config.js
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  kit: {
+    serviceWorker: {
+      register: false
+    }
+  }
+};
+```
+
+You can also configure a custom service worker name, `SvelteKitPWA` plugin will update the file properly (remember to also update the service worker name in `SvelteKitPWA` plugin configuration):
+```ts
+// svelte.config.js
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  kit: {
+    files: {
+      serviceWorker: 'src/prompt-sw.ts',
+    }
+  }
+};
+```
 :::
 
 ## SvelteKit PWA Plugin

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -5,9 +5,9 @@ title: SvelteKit | Frameworks
 # SvelteKit
 
 ::: warning
-From version `^0.1.4`, `SvelteKitPWA` plugin will assume you're using latest `SvelteKit`.
+From version `^0.2.0`, `SvelteKitPWA` plugin will assume you're using latest `SvelteKit`.
 
-If you're using old `SvelteKit` versions between `1.0.*` and `1.3.0`, add `latestKit: false` to kit plugin options.
+If you're using old `SvelteKit` versions between `1.0.*` and `1.3.0`, you should use old `0.1.*` `SvelteKitPWA` plugin version.
 :::
 
 ::: tip
@@ -19,9 +19,12 @@ For `Type declarations`, `Prompt for update` and `Periodic SW Updates` go to [Sv
 :::
 
 ::: tip
-If you're using an old `SvelteKit` version from `1.0.*` to `1.3.2`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
+If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
+:::
 
-From version `0.1.4`, `SvelteKitPWA` plugin will delegate the service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
+## Generate Custom TypeScript SW
+
+From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
 You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
 ```ts
 // svelte.config.js
@@ -47,6 +50,20 @@ const config = {
   }
 };
 ```
+
+::: warning
+If your custom service working is importing any `workbox-*` module (`workbox-routing`, `workbox-strategies`, etc), you will need to hack Vite build process in order to remove non `ESM` special replacements from the build process (if you don't include `process.env.NODE_ENV`, the service worker will not be registered). You only need to add this entry in your Vite config file:
+```ts
+// vite.config.js or vite.config.ts
+/** @type {import('vite').UserConfig} */
+const config = {
+  define: {
+    'process.env.NODE_ENV': process.env.NODE_ENV === 'production' ? '"production"' : '"development"'
+  }
+};
+
+export default config;
+```
 :::
 
 ## SvelteKit PWA Plugin
@@ -60,7 +77,7 @@ pnpm add -D @vite-pwa/sveltekit
 
 To update your project to use the new `vite-plugin-pwa` for SvelteKit, you only need to change the Vite config file (you don't need oldest `pwa` and `pwa-configuration` modules):
 ```ts
-// vite.config.js / vite-config.ts
+// vite.config.js / vite.config.ts
 import { SvelteKitPWA } from '@vite-pwa/sveltekit'
 
 /** @type {import('vite').UserConfig} */

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -58,7 +58,9 @@ If your custom service working is importing any `workbox-*` module (`workbox-rou
 /** @type {import('vite').UserConfig} */
 const config = {
   define: {
-    'process.env.NODE_ENV': process.env.NODE_ENV === 'production' ? '"production"' : '"development"'
+    'process.env.NODE_ENV': process.env.NODE_ENV === 'production' 
+      ? '"production"'
+      : '"development"'
   }
 };
 

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -22,7 +22,7 @@ For `Type declarations`, `Prompt for update` and `Periodic SW Updates` go to [Sv
 If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all references to [SvelteKit service worker module](https://kit.svelte.dev/docs/modules#$service-worker) to disable it on your application.
 :::
 
-## Generate Custom TypeScript SW
+## Generate Custom Service Worker
 
 From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
 You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
@@ -38,7 +38,7 @@ const config = {
 };
 ```
 
-You can also configure a custom service worker name, `SvelteKitPWA` plugin will update the file properly (remember to also update the service worker name in `SvelteKitPWA` plugin configuration):
+You can also configure a custom service worker name, `SvelteKitPWA` plugin will rename your service worker (remember to also update the service worker name in `SvelteKitPWA` plugin configuration):
 ```ts
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -26,7 +26,7 @@ If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all referen
 
 From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
 You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
-```ts
+```js
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -39,7 +39,7 @@ const config = {
 ```
 
 You can also configure a custom service worker name, `SvelteKitPWA` plugin will rename your service worker (remember to also update the service worker name in `SvelteKitPWA` plugin configuration):
-```ts
+```js
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -51,9 +51,11 @@ const config = {
 };
 ```
 
+You can check SvelteKit docs for more information about [Service Worker](https://kit.svelte.dev/docs/service-workers).
+
 ::: warning
 If your custom service working is importing any `workbox-*` module (`workbox-routing`, `workbox-strategies`, etc), you will need to hack Vite build process in order to remove non `ESM` special replacements from the build process (if you don't include `process.env.NODE_ENV`, the service worker will not be registered). You only need to add this entry in your Vite config file:
-```ts
+```js
 // vite.config.js or vite.config.ts
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -78,7 +80,7 @@ pnpm add -D @vite-pwa/sveltekit
 ```
 
 To update your project to use the new `vite-plugin-pwa` for SvelteKit, you only need to change the Vite config file (you don't need oldest `pwa` and `pwa-configuration` modules):
-```ts
+```js
 // vite.config.js / vite.config.ts
 import { SvelteKitPWA } from '@vite-pwa/sveltekit'
 

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -35,8 +35,43 @@ const config = {
     }
   }
 };
+```
+
+Then in your Vite config file:
+```js
+// vite.config.js or vite.config.ts
+/** @type {import('vite').UserConfig} */
+const config = {
+  plugins: [
+    sveltekit(),
+    SvelteKitPWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'my-sw.js', // or `my-sw.ts`
+      /* other pwa options */  
+    })
+  ],
+};
+
+export default config;
+```
 
 You can check SvelteKit docs for more information about [service workers](https://kit.svelte.dev/docs/service-workers).
+
+You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any pwa virtual module (`virtual:pwa-register` or `virtual:pwa-register/svelte`):
+```js
+// svelte.config.js
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  plugins: {
+    serviceWorker: {
+      register: false
+    }
+  }
+};
+
+export default config;
+```
 
 ::: warning
 If your custom service working is importing any `workbox-*` module (`workbox-routing`, `workbox-strategies`, etc), you will need to hack Vite build process in order to remove non `ESM` special replacements from the build process (if you don't include `process.env.NODE_ENV`, the service worker will not be registered). You only need to add this entry in your Vite config file:

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -24,33 +24,17 @@ If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all referen
 
 ## Generate Custom Service Worker
 
-From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `src/service-worker.js`: in that case, you don't need to configure the `filename` in pwa plugin options.
-
-You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
-```js
-// svelte.config.js
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-  kit: {
-    serviceWorker: {
-      register: false
-    }
-  }
-};
-```
-
-You can also configure a custom service worker, remember to also update the service worker name in `SvelteKitPWA` plugin configuration, for example:
+From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so by default you will be expected to put your service worker in `src/service-worker.js`. If you would like, you can use a custom file location by changing the corresponding SvelteKit option:
 ```js
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
     files: {
-      serviceWorker: 'src/prompt-sw.js', // or `src/prompt-sw.ts`
+      serviceWorker: 'src/my-sw.js', // or `src/my-sw.ts`
     }
   }
 };
-```
 
 You can check SvelteKit docs for more information about [service workers](https://kit.svelte.dev/docs/service-workers).
 

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -4,6 +4,12 @@ title: SvelteKit | Frameworks
 
 # SvelteKit
 
+::: warning
+From version `^0.1.4`, `SvelteKitPWA` plugin will assume you're using latest `SvelteKit`.
+
+If you're using old `SvelteKit` versions between `1.0.*` and `1.3.0`, add `latestKit: false` to kit plugin options.
+:::
+
 ::: tip
 From version `^0.1.0`, `SvelteKitPWA` has SvelteKit `^1.0.0` as peer dependency.
 :::
@@ -73,6 +79,12 @@ export interface KitOptions {
    * @see https://kit.svelte.dev/docs/configuration#trailingslash
    */
   trailingSlash?: 'never' | 'always' | 'ignore'
+  /**
+   * If you're using older version of SvelteKit, you can set this to `false`.
+   *
+   * @default true
+   */
+  latestKit?: boolean
 }
 
 export interface SvelteKitPWAOptions extends Partial<VitePWAOptions> {

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -5,7 +5,7 @@ title: SvelteKit | Frameworks
 # SvelteKit
 
 ::: warning
-From version `v0.2.0`, `SvelteKitPWA` plugin requires SvelteKit 1.3.1+.
+From version `v0.2.0`, `SvelteKitPWA` plugin requires SvelteKit 1.3.1 or above.
 
 If you're using old `SvelteKit` version previous to `v1.3.1`, you should use old `0.1.*` `SvelteKitPWA` plugin version.
 :::

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -7,7 +7,7 @@ title: SvelteKit | Frameworks
 ::: warning
 From version `v0.2.0`, `SvelteKitPWA` plugin requires SvelteKit 1.3.1 or above.
 
-If you're using old `SvelteKit` version previous to `v1.3.1`, you should use old `0.1.*` `SvelteKitPWA` plugin version.
+If you're using a `SvelteKit` version prior to `v1.3.1`, you should use `SvelteKitPWA` plugin version `0.1.*`.
 :::
 
 ::: tip

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -24,7 +24,8 @@ If you're using `0.1.*` version of `SvelteKitPWA`, you should remove all referen
 
 ## Generate Custom Service Worker
 
-From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `service-worker` as the name of your service worker file (VanillaJS or TypeScript).
+From version `0.2.0`, `SvelteKitPWA` plugin will delegate your custom service worker build to `SvelteKit`, and so, you can use `src/service-worker.js`: in that case, you don't need to configure the `filename` in pwa plugin options.
+
 You will need to exclude the service worker registration from the `SvelteKit` configuration if you're using any virtual module:
 ```js
 // svelte.config.js
@@ -38,14 +39,14 @@ const config = {
 };
 ```
 
-You can also configure a custom service worker name, `SvelteKitPWA` plugin will rename your service worker (remember to also update the service worker name in `SvelteKitPWA` plugin configuration):
+You can also configure a custom service worker, remember to also update the service worker name in `SvelteKitPWA` plugin configuration, for example:
 ```js
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   kit: {
     files: {
-      serviceWorker: 'src/prompt-sw.ts',
+      serviceWorker: 'src/prompt-sw.js', // or `src/prompt-sw.ts`
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-pwa-docs",
-  "version": "0.14.1",
-  "packageManager": "pnpm@7.26.1",
+  "version": "0.14.4",
+  "packageManager": "pnpm@7.29.1",
   "description": "Zero-config PWA for Vite Documentation",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-pwa-docs",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "packageManager": "pnpm@7.29.1",
   "description": "Zero-config PWA for Vite Documentation",
   "author": "antfu <anthonyfu117@hotmail.com>",


### PR DESCRIPTION
Add the new kit option `latestKit` and the corresponding warning: https://github.com/vite-pwa/sveltekit/pull/32.

/cc @benmccann should we release a minor (breaking changes: check the warning on the page)?