### PR TITLE
fix: wrong edit page link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -279,7 +279,7 @@ export default withPwa(defineConfig({
   themeConfig: {
     // logo: '/favicon.svg',
     editLink: {
-      pattern: 'https://github.com/vite-pwa/docs/edit/main/docs/:path',
+      pattern: 'https://github.com/vite-pwa/docs/edit/main/:path',
       text: 'Suggest changes to this page',
     },
     algolia: {

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -65,7 +65,7 @@ You will need to exclude the service worker registration from the `SvelteKit` co
 // svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  plugins: {
+  kit: {
     serviceWorker: {
       register: false
     }


### PR DESCRIPTION
This PR also updates SvelteKit entry about disabling kit sw registration, `plugins` entry is wrong, it should be `kit`.