### PR TITLE
docs: update react and preact hook warn

### DIFF
--- a/.vitepress/theme/components/ReactReactiveWarning.md
+++ b/.vitepress/theme/components/ReactReactiveWarning.md
@@ -1,0 +1,3 @@
+::: warning
+The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.
+:::

--- a/frameworks/preact.md
+++ b/frameworks/preact.md
@@ -50,6 +50,8 @@ declare module 'virtual:pwa-register/preact' {
 
 ## Prompt for update
 
+<ReactReactiveWarning />
+
 You can use this `ReloadPrompt.tsx` component:
 
 ::: details ReloadPrompt.tsx
@@ -134,10 +136,6 @@ and its corresponding `ReloadPrompt.css` styles file:
     padding: 3px 10px;
 }
 ```
-:::
-
-::: warning
-The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.
 :::
 
 ## Periodic SW Updates

--- a/frameworks/preact.md
+++ b/frameworks/preact.md
@@ -136,6 +136,10 @@ and its corresponding `ReloadPrompt.css` styles file:
 ```
 :::
 
+::: warning
+The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.
+:::
+
 ## Periodic SW Updates
 
 As explained in [Periodic Service Worker Updates](/guide/periodic-sw-updates), you can use this code to configure this behavior on your application with the virtual module `virtual:pwa-register/preact`:

--- a/frameworks/react.md
+++ b/frameworks/react.md
@@ -50,6 +50,8 @@ declare module 'virtual:pwa-register/react' {
 
 ## Prompt for update
 
+<ReactReactiveWarning />
+
 You can use this `ReloadPrompt.tsx` component:
 
 :::details ReloadPrompt.tsx
@@ -135,10 +137,6 @@ and its corresponding `ReloadPrompt.css` styles file:
     padding: 3px 10px;
 }
 ```
-:::
-
-::: warning
-The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.
 :::
 
 ## Periodic SW Updates

--- a/frameworks/react.md
+++ b/frameworks/react.md
@@ -137,6 +137,10 @@ and its corresponding `ReloadPrompt.css` styles file:
 ```
 :::
 
+::: warning
+The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.
+:::
+
 ## Periodic SW Updates
 
 As explained in [Periodic Service Worker Updates](/guide/periodic-sw-updates), you can use this code to configure this behavior on your application with the virtual module `virtual:pwa-register/react`:


### PR DESCRIPTION
For React and Preact:

- Addressing https://github.com/vite-pwa/vite-plugin-pwa/issues/536
- Warn about the options is not reactive

The text added:
> The options provided to hooks are not reactive. Therefore, the callback references will be the first rendered options instead of the latest hook’s options. If you are doing complex logic with state changes, you will need to provide a stable reference function.

![image](https://github.com/vite-pwa/docs/assets/18393696/bb8b2ec4-e7c8-42bb-be72-ddd4a15f9b19)

---

Although other frameworks examples may also suffer from same behavior, React and Preact are more likely to be misused due to how reactive works in both of them.