### PR TITLE
docs: Easier component lazy-load method

### DIFF
--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -241,13 +241,7 @@ The best place to include the `ReloadPrompt` component will be in main layout of
 ::: details src/routes/+layout.svelte
 ```html
 <script>
-  import { onMount } from 'svelte'
   import { pwaInfo } from 'virtual:pwa-info'
-
-  let ReloadPrompt
-  onMount(async () => {
-    pwaInfo && (ReloadPrompt = (await import('$lib/ReloadPrompt.svelte')).default)
-  })
 
   $: webManifest = pwaInfo ? pwaInfo.webManifest.linkTag : ''  
 </script>
@@ -260,9 +254,9 @@ The best place to include the `ReloadPrompt` component will be in main layout of
   <slot />
 </main>
 
-{#if ReloadPrompt}
-  <svelte:component this={ReloadPrompt} />
-{/if}
+{#await import('$lib/ReloadPrompt.svelte') then { default: ReloadPrompt}}
+  <ReloadPrompt />
+{/await}
 ```
 :::
 


### PR DESCRIPTION
Just a stylistic adjustment - this is a cleaner method of lazy-loading in Svelte components client-side. Don't know if you care. :)

Pairs with https://github.com/vite-pwa/sveltekit/pull/57