### PR TITLE
Update inject-manifest.md

### DIFF
--- a/guide/inject-manifest.md
+++ b/guide/inject-manifest.md
@@ -65,11 +65,11 @@ injectManifest: {
 
 ### Service worker errors on browser
 
-If your service worker code is being compiled with unexpected `exports` (for example: `export default require_sw();`), you can change the build output format to `iief`, add the following code to your pwa configuration:
+If your service worker code is being compiled with unexpected `exports` (for example: `export default require_sw();`), you can change the build output format to `iife`, add the following code to your pwa configuration:
 
 ```ts
 injectManifest: {
-  rollupFormat: 'iief'
+  rollupFormat: 'iife'
 }
 ```
 


### PR DESCRIPTION
In the injectManifest:{rollupFormat: 'iife'}, the rollup format was specified as iief instead of iife. It was like that in the comment as well. I've corrected it to say IIFE.

Ran this while facing the vague exports error myself. "iife" is the correct term to be passed to the rollup options not "iief".