### PR TITLE
docs: fix broken link to Elk PWA page

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -14,7 +14,7 @@ A PWA mainly consists of a [Web App Manifest](https://developer.mozilla.org/en-U
 
 If you are new to **Progressive Web Apps (PWA)**, we suggest read this guide before starting writing code: [Learn PWA](https://web.dev/learn/pwa/).
 
-Check out [Elk PWA Documentation](https://docs.elk.zone/docs/pwa) for some useful PWA hints for users and developers.
+Check out [Elk PWA Documentation](https://docs.elk.zone/pwa) for some useful PWA hints for users and developers.
 
 ## Service Worker
 


### PR DESCRIPTION
What title says :P 

PD: Is the [`docs` dir in `vite-plugin-pwa`](https://github.com/vite-pwa/vite-plugin-pwa/tree/31ccaa89bb18b7d39f8d150435b26d33dfee04dd/docs) used? Seems like a replica of this repo. I can make a PR in there to remove that if it's helpful :) 

thx