### PR TITLE
docs: bump VP to rc10

### DIFF
--- a/.vitepress/theme/PwaLayout.vue
+++ b/.vitepress/theme/PwaLayout.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import DefaultTheme, { VPHomeHero, VPImage } from 'vitepress/theme'
+import type { DefaultTheme as DTheme } from 'vitepress/theme'
+import { nextTick, provide } from 'vue'
+import HomePage from './components/HomePage.vue'
+import ReloadPrompt from './components/ReloadPrompt.vue'
+
+const { isDark } = useData()
+
+const image: DTheme.ThemeableImage = {
+  light: '/icon_light.svg',
+  dark: '/icon_dark.svg',
+  alt: 'Vite PWA Logo',
+}
+
+function enableTransitions() {
+  return 'startViewTransition' in document
+    && window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+}
+
+provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
+  if (!enableTransitions()) {
+    isDark.value = !isDark.value
+    return
+  }
+
+  const clipPath = [
+    `circle(0px at ${x}px ${y}px)`,
+    `circle(${Math.hypot(
+        Math.max(x, innerWidth - x),
+        Math.max(y, innerHeight - y),
+    )}px at ${x}px ${y}px)`,
+  ]
+
+  await document.startViewTransition(async () => {
+    isDark.value = !isDark.value
+    await nextTick()
+  }).ready
+
+  document.documentElement.animate(
+    { clipPath: isDark.value ? clipPath.reverse() : clipPath },
+    {
+      duration: 300,
+      easing: 'ease-in',
+      pseudoElement: `::view-transition-${isDark.value ? 'old' : 'new'}(root)`,
+    },
+  )
+})
+</script>
+
+<template>
+  <DefaultTheme.Layout>
+    <template #home-hero>
+      <VPHomeHero>
+        <template #home-hero-image>
+          <VPImage :image="image" />
+        </template>
+      </VPHomeHero>
+    </template>
+    <template #home-features-after>
+      <HomePage />
+    </template>
+    <template #layout-bottom>
+      <ReloadPrompt />
+    </template>
+  </DefaultTheme.Layout>
+</template>

--- a/.vitepress/theme/PwaLayout.vue
+++ b/.vitepress/theme/PwaLayout.vue
@@ -1,18 +1,11 @@
 <script setup lang="ts">
 import { useData } from 'vitepress'
-import DefaultTheme, { VPHomeHero, VPImage } from 'vitepress/theme'
-import type { DefaultTheme as DTheme } from 'vitepress/theme'
+import DefaultTheme from 'vitepress/theme'
 import { nextTick, provide } from 'vue'
 import HomePage from './components/HomePage.vue'
 import ReloadPrompt from './components/ReloadPrompt.vue'
 
 const { isDark } = useData()
-
-const image: DTheme.ThemeableImage = {
-  light: '/icon_light.svg',
-  dark: '/icon_dark.svg',
-  alt: 'Vite PWA Logo',
-}
 
 function enableTransitions() {
   return 'startViewTransition' in document
@@ -51,13 +44,6 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
 
 <template>
   <DefaultTheme.Layout>
-    <template #home-hero>
-      <VPHomeHero>
-        <template #home-hero-image>
-          <VPImage :image="image" />
-        </template>
-      </VPHomeHero>
-    </template>
     <template #home-features-after>
       <HomePage />
     </template>

--- a/.vitepress/theme/components/ReloadPrompt.vue
+++ b/.vitepress/theme/components/ReloadPrompt.vue
@@ -22,7 +22,7 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-  <template v-if="needRefresh">
+  <template v-if="!needRefresh">
     <div
       class="pwa-toast z-100 bg-$vp-c-bg b b-solid b-1px b-color-$pwa-border fixed right-0 bottom-0 m-6 px-6 py-4 rounded-2 shadow-xl"
       role="alertdialog"

--- a/.vitepress/theme/components/ReloadPrompt.vue
+++ b/.vitepress/theme/components/ReloadPrompt.vue
@@ -26,7 +26,7 @@ onBeforeMount(async () => {
     <div
       class="pwa-toast z-100 bg-$vp-c-bg b b-solid b-1px b-color-$pwa-border fixed right-0 bottom-0 m-6 px-6 py-4 rounded-2 shadow-xl"
       role="alertdialog"
-      aria-labelledby="pwa-title pwa-message"
+      aria-labelledby="pwa-message"
     >
       <div id="pwa-message" class="mb-3">
         New content available, click the reload button to update.

--- a/.vitepress/theme/components/ReloadPrompt.vue
+++ b/.vitepress/theme/components/ReloadPrompt.vue
@@ -22,7 +22,7 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-  <template v-if="!needRefresh">
+  <template v-if="needRefresh">
     <div
       class="pwa-toast z-100 bg-$vp-c-bg b b-solid b-1px b-color-$pwa-border fixed right-0 bottom-0 m-6 px-6 py-4 rounded-2 shadow-xl"
       role="alertdialog"

--- a/.vitepress/theme/components/ReloadPrompt.vue
+++ b/.vitepress/theme/components/ReloadPrompt.vue
@@ -24,9 +24,9 @@ onBeforeMount(async () => {
 <template>
   <template v-if="needRefresh">
     <div
-      class="pwa-toast z-100 bg-$vp-c-bg border border-$pwa-divider fixed right-0 bottom-0 m-6 px-6 py-4 rounded shadow-xl"
+      class="pwa-toast z-100 bg-$vp-c-bg b b-solid b-1px b-color-$pwa-border fixed right-0 bottom-0 m-6 px-6 py-4 rounded-2 shadow-xl"
       role="alertdialog"
-      aria-labelledby="pwa-message"
+      aria-labelledby="pwa-title pwa-message"
     >
       <div id="pwa-message" class="mb-3">
         New content available, click the reload button to update.
@@ -40,7 +40,7 @@ onBeforeMount(async () => {
       </button>
       <button
         type="button"
-        class="pwa-cancel border border-$pwa-divider mr-2 px-3 py-1 rounded"
+        class="pwa-cancel b b-solid b-1px !b-color-$pwa-border mr-2 px-3 py-1 rounded"
         @click="close"
       >
         Close

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,20 +1,15 @@
 import { h } from 'vue'
 import Theme from 'vitepress/theme'
+import PwaLayout from './PwaLayout.vue'
 
 import './styles/main.css'
 import './styles/vars.css'
 
 import 'uno.css'
 
-import HomePage from './components/HomePage.vue'
-import ReloadPrompt from './components/ReloadPrompt.vue'
-
 export default {
   ...Theme,
   Layout() {
-    return h(Theme.Layout, null, {
-      'home-features-after': () => h(HomePage),
-      'layout-bottom': () => h(ReloadPrompt),
-    })
+    return h(PwaLayout)
   },
 }

--- a/.vitepress/theme/styles/main.css
+++ b/.vitepress/theme/styles/main.css
@@ -1,50 +1,16 @@
+/* show/hide PWA icon in navbar */
 .dark [img-light],
 .dark .logo[light-logo] {
   display: none;
 }
-
 html:not(.dark) [img-dark],
 html:not(.dark) .logo[dark-logo] {
   display: none;
 }
 
 /* Overrides */
-
 .VPSocialLink {
   transform: scale(0.9);
-}
-
-.vp-doc th,
-.vp-doc td {
-  padding: 6px 10px;
-  border: 1px solid #8882;
-}
-
-html:not(.dark) .vp-doc [class*=language-]:before {
-  color: var(--vp-custom-block-details-text);
-}
-
-html:not(.dark) .vp-doc [class*='language-']:not(:hover) > span.copy,
-html:not(.dark) .vp-doc [class*='language-']:not(:hover) > span.copy.copied:before {
-  background-color: var(--vp-code-block-hover-bg);
-  opacity: 0;
-}
-
-html:not(.dark) .vp-doc [class*='language-']:hover > span.copy:hover {
-  opacity: 1;
-  background-color: var(--vp-code-block-hover-bg);
-}
-
-html:not(.dark) .vp-doc [class*='language-']:hover > span.copy.copied,
-html:not(.dark) .vp-doc [class*='language-']:hover > span.copy.copied:hover {
-  opacity: 1;
-  background-color: var(--vp-code-block-hover-bg);
-}
-
-html:not(.dark) .vp-doc [class*='language-']:hover > span.copy.copied:before,
-html:not(.dark) .vp-doc [class*='language-']:hover > span.copy.copied:hover:before {
-  color: var(--vp-custom-block-details-text);
-  background-color: var(--vp-code-block-hover-bg);
 }
 
 /* h3 breaks SEO => replaced with h2 with the same size */
@@ -70,22 +36,16 @@ img.resizable-img {
 
 details > summary:hover {
   cursor: pointer;
+  user-select: none;
 }
 
-.custom-block.warning code {
+.custom-block.warning code,
+.custom-block.danger code {
   font-size: var(--vp-custom-block-code-font-size);
   font-weight: 700;
 }
 
-/* remove the gray color from code block inside details > summary */
-.vp-doc .custom-block div[class*=language-] code,
-.vp-doc details > summary + div[class*='language-'] > pre > code {
-  --vp-code-block-bg: transparent;
-}
-
-.pwa-toast {
-  --c-divider: var(--vp-c-divider-light);
-}
+/* PWA: Prompt for Update */
 .pwa-toast .pwa-refresh {
   border-color: var(--vp-button-brand-border);
   color: var(--vp-button-brand-text);
@@ -116,14 +76,13 @@ details > summary:hover {
   color: var(--vp-button-alt-active-text);
   background-color: var(--vp-button-alt-active-bg);
 }
-.dark .pwa-toast {
-  --pwa-divider: var(--vp-c-divider-dark-1);
-}
 
+/* code block with pre padding */
 .vp-doc :not(pre) > code {
   padding: 1px 6px;
 }
 
+/* Team member media queries */
 /* fix height ~ 2 lines of text: 3 cards per row */
 .VPTeamMembersItem.medium .profile .data .affiliation {
   min-height: 3rem;
@@ -160,7 +119,65 @@ details > summary:hover {
   }
 }
 
-/* transitions */
+/* Excalidraw SVG colors */
+/* Vite purple color */
+html:not(.dark) svg g > text[fill="#646cff"] {
+  fill: #5d65ee;
+}
+html.dark svg g > text[fill="#646cff"] {
+  fill: #6d75ff;
+}
+/* Vite circles */
+html:not(.dark) svg g[stroke-linecap="round"] > path[stroke="#646cff"] {
+  stroke: #5d65ee;
+}
+html.dark svg g[stroke-linecap="round"] > path[stroke="#646cff"] {
+  stroke: #6d75ff;
+}
+/* Vite green text */
+html:not(.dark) svg g > text[fill="#2f9e44"] {
+  fill: #28863a;
+}
+/* Vite green rectangle */
+html:not(.dark) svg g[stroke-linecap="round"] > path[stroke="#2f9e44"] {
+  stroke: #28863a;
+}
+/* Vite plugins rectangle */
+html.dark svg g[stroke-linecap="round"] > path[stroke="#1e1e1e"] {
+  stroke: #fff;
+}
+/* Rollup links */
+html.dark svg g > text[fill="#e03131"] {
+  fill: #f93636;
+}
+/* Rollup circles */
+html.dark svg g[stroke-linecap="round"] > path[stroke="#e03131"] {
+  stroke: #f93636;
+}
+/* PWA blue color */
+svg g > text[fill="#35849a"] {
+  fill: var(--vp-c-brand-1);
+}
+/* PWA circles and arrows */
+svg g[stroke-linecap="round"] > path[stroke="#35849a"],
+svg g[stroke-linecap="round"] > g > path[stroke="#35849a"] {
+  stroke: var(--vp-c-brand-1);
+}
+/* workbox rectangle */
+html:not(.dark) svg g[stroke-linecap="round"] > path[stroke="#f08c00"],
+/* workbox arrows */
+html:not(.dark) svg g[stroke-linecap="round"] > g > path[stroke="#f08c00"],
+/* workbox circles */
+html:not(.dark) svg g[stroke-linecap="round"] > path[stroke="#fa903e"] {
+  stroke: #ab6400;
+}
+/* workbox text */
+html:not(.dark) svg g > text[fill="#f08c00"],
+html:not(.dark) svg g > text[fill="#fa903e"] {
+  fill: #ab6400;
+}
+
+/* dark/light radial transition */
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation: none;

--- a/.vitepress/theme/styles/main.css
+++ b/.vitepress/theme/styles/main.css
@@ -71,6 +71,12 @@ img.resizable-img {
 details > summary:hover {
   cursor: pointer;
 }
+
+.custom-block.warning code {
+  font-size: var(--vp-custom-block-code-font-size);
+  font-weight: 700;
+}
+
 /* remove the gray color from code block inside details > summary */
 .vp-doc .custom-block div[class*=language-] code,
 .vp-doc details > summary + div[class*='language-'] > pre > code {
@@ -153,3 +159,22 @@ details > summary:hover {
     min-height: unset;
   }
 }
+
+/* transitions */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root),
+.dark::view-transition-new(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root),
+.dark::view-transition-old(root) {
+  z-index: 9999;
+}
+
+

--- a/.vitepress/theme/styles/vars.css
+++ b/.vitepress/theme/styles/vars.css
@@ -1,102 +1,59 @@
 /**
  * Colors
  * -------------------------------------------------------------------------- */
-
 :root {
-  --vp-c-accent: #2c7f95;
-  --vp-c-brand: #2c7f95;
-  --vp-c-brand-light: #2e859c;
-  --vp-c-brand-lighter: #3392ac;
-  --vp-c-brand-dark: #00586e;
-  --vp-c-brand-darker: #00586e;
-  --vp-c-text-light-2: rgba(56, 56, 56, 0.75);
-  --vp-c-text-code: #2c3e50;
-  --vp-code-block-bg: rgba(125, 125, 125, 0.06);
-  --vp-code-block-hover-bg: rgba(125, 125, 125, 0.1);
-  --vp-c-bg-mute: #f5f5f5;
-  --vp-custom-block-tip-border: var(--vp-c-brand);
-  --vp-custom-block-tip-text: var(--vp-c-brand-dark);
-  --vp-custom-block-tip-bg: transparent;
-  --vp-custom-block-tip-code-bg: var(--vp-custom-block-tip-bg);
-  --vp-c-text-dark-3: rgba(56, 56, 56, 0.8);
-  --vp-code-copy-code-bg: initial;
-  --vp-code-copy-code-hover-bg: rgba(125, 125, 125, 0.2);
-  --vp-code-copy-code-active-text: var(--vp-c-text-dark-3);
-  --vp-custom-block-warning-border: #827717;
-  --vp-custom-block-warning-text: #827717;
-  --vp-custom-block-warning-bg: #ffffe777;
-  --vp-custom-block-danger-border: #b71c1c;
-  --vp-custom-block-danger-text: #b71c1c;
-  --vp-custom-block-danger-bg: #ffebee77;
-  /* new VP vars */
   --vp-c-brand-1: #00586e;
   --vp-c-brand-2: #2E859C;
   --vp-c-brand-3: #2c7f95;
-  --vp-code-bg: #eeeef0;
-  --vp-code-color: #2c3e50;
-  --vp-custom-block-warning-code-bg: #eeeef0;
-  --vp-c-warning-1: var(--vp-custom-block-warning-border);
-  /* end new VP vars */
+  --vp-c-warning-1: #827717;
+  --vp-c-warning-soft: #eeeef0;
+  --vp-c-danger-1: #b71c1c;
+  --vp-c-danger-soft: #ffebee77;
+  /* pwa prompt divider */
+  --pwa-border: #e5e5e5;
 }
-
 .dark {
-  --vp-c-accent: #4aa6c0;
-  --vp-c-brand: #4aa6c0;
-  --vp-c-brand-light: #52b1cc;
-  --vp-c-brand-lighter: #52b1cc;
-  --vp-c-brand-dark: #52b1cc;
-  --vp-c-brand-darker: #52b1cc;
-  --vp-code-block-bg: rgba(0, 0, 0, 0.2);
-  --vp-c-text-code: #f5f7fa;
-  --vp-c-bg-mute: #2d2d2d;
-  --vp-c-text-dark-3: var(--vp-c-text-dark-2);
-  --vp-code-copy-code-bg: initial;
-  --vp-code-copy-code-hover-bg: rgba(255, 255, 255, 0.05);
-  --vp-custom-block-warning-border: rgb(234 179 6 / 50%);
-  --vp-custom-block-warning-text: #EAB306;
-  --vp-custom-block-warning-bg: var(--vp-c-bg-soft-up);
-  /*--vp-custom-block-danger-border: #bf0808;
-  --vp-custom-block-danger-text: #bf0808;
-  --vp-custom-block-danger-bg: #ffffffd6;*/
-  --vp-custom-block-danger-border: var(--vp-c-text-code);
-  --vp-custom-block-danger-text: var(--vp-c-text-code);
-  --vp-custom-block-danger-bg: #660000;
-  /* new VP vars */
   --vp-c-brand-1: #4ba8c2;
   --vp-c-brand-2: #52b1cc;
-  --vp-code-bg: #323238;
-  --vp-code-color: #f5f7fa;
-  --vp-custom-block-warning-code-bg: transparent;
-  --vp-c-warning-1: var(--vp-custom-block-warning-text);
-  /* end new VP vars */
+  --vp-c-warning-1: #EAB306;
+  --vp-c-danger-1: #fff;
+  --vp-c-danger-soft: #660000;
+  /* pwa prompt divider */
+  --pwa-border: #ffffff75;
 }
 
 /**
- * Component: Button
+ * Component: Custom Block
  * -------------------------------------------------------------------------- */
-
 :root {
-  --vp-button-brand-border: var(--vp-c-brand-light);
-  --vp-button-brand-text: white;
-  --vp-button-alt-border: #c2c2c4;
-  --vp-button-brand-bg: var(--vp-c-brand);
-  --vp-button-brand-hover-border: var(--vp-c-brand-light);
-  --vp-button-brand-hover-text: white;
-  --vp-button-brand-hover-bg: var(--vp-c-brand-light);
-  --vp-button-brand-active-border: var(--vp-c-brand-light);
-  --vp-button-brand-active-text: var(--vp-c-text-dark-1);
-  --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+  --vp-custom-block-info-border: var(--vp-c-border);
+  --vp-custom-block-info-text: var(--vp-c-text-2);
+  --vp-custom-block-info-bg: var(--vp-c-default-soft);
+  --vp-custom-block-info-code-bg: var(--vp-c-default-soft);
 
-  --vp-button-alt-hover-border: #c2c2c4;
-  --vp-button-alt-hover-bg: #e3e3e5;
+  --vp-custom-block-tip-border: var(--vp-c-brand-1);
+  --vp-custom-block-tip-text: var(--vp-c-brand-1);
+  --vp-custom-block-tip-bg: tranparent;
+  --vp-custom-block-tip-code-bg: var(--vp-c-default-soft);
+
+  --vp-custom-block-warning-border: var(--vp-c-warning-1);
+  --vp-custom-block-warning-text: var(--vp-c-warning-1);
+  --vp-custom-block-warning-bg: #ffffe777;
+  --vp-custom-block-warning-code-bg: var(--vp-c-warning-soft);
+
+  --vp-custom-block-danger-border: var(--vp-c-danger-1);
+  --vp-custom-block-danger-text: var(--vp-c-danger-1);
+  --vp-custom-block-danger-bg: var(--vp-c-danger-soft);
+  --vp-custom-block-danger-code-bg: #eeeef0;
 }
 
 .dark {
-  --vp-button-brand-text: black;
-  --vp-button-brand-hover-text: black;
-  --vp-button-alt-border: rgba(82, 82, 89, .68);
-  --vp-button-alt-bg: #323238;
-  --vp-button-alt-hover-bg: #222226;
+  --vp-custom-block-warning-border: #827717;
+  --vp-custom-block-warning-text: #EAB306;
+  --vp-custom-block-warning-bg: #323238;
+  --vp-custom-block-warning-code-bg: #323238;
+
+  --vp-custom-block-danger-code-bg: #323238;
 }
 
 /**

--- a/.vitepress/theme/styles/vars.css
+++ b/.vitepress/theme/styles/vars.css
@@ -28,6 +28,15 @@
   --vp-custom-block-danger-border: #b71c1c;
   --vp-custom-block-danger-text: #b71c1c;
   --vp-custom-block-danger-bg: #ffebee77;
+  /* new VP vars */
+  --vp-c-brand-1: #00586e;
+  --vp-c-brand-2: #2E859C;
+  --vp-c-brand-3: #2c7f95;
+  --vp-code-bg: #eeeef0;
+  --vp-code-color: #2c3e50;
+  --vp-custom-block-warning-code-bg: #eeeef0;
+  --vp-c-warning-1: var(--vp-custom-block-warning-border);
+  /* end new VP vars */
 }
 
 .dark {
@@ -52,6 +61,14 @@
   --vp-custom-block-danger-border: var(--vp-c-text-code);
   --vp-custom-block-danger-text: var(--vp-c-text-code);
   --vp-custom-block-danger-bg: #660000;
+  /* new VP vars */
+  --vp-c-brand-1: #4ba8c2;
+  --vp-c-brand-2: #52b1cc;
+  --vp-code-bg: #323238;
+  --vp-code-color: #f5f7fa;
+  --vp-custom-block-warning-code-bg: transparent;
+  --vp-c-warning-1: var(--vp-custom-block-warning-text);
+  /* end new VP vars */
 }
 
 /**
@@ -60,14 +77,26 @@
 
 :root {
   --vp-button-brand-border: var(--vp-c-brand-light);
-  --vp-button-brand-text: var(--vp-c-text-dark-1);
+  --vp-button-brand-text: white;
+  --vp-button-alt-border: #c2c2c4;
   --vp-button-brand-bg: var(--vp-c-brand);
   --vp-button-brand-hover-border: var(--vp-c-brand-light);
-  --vp-button-brand-hover-text: var(--vp-c-text-dark-1);
+  --vp-button-brand-hover-text: white;
   --vp-button-brand-hover-bg: var(--vp-c-brand-light);
   --vp-button-brand-active-border: var(--vp-c-brand-light);
   --vp-button-brand-active-text: var(--vp-c-text-dark-1);
   --vp-button-brand-active-bg: var(--vp-button-brand-bg);
+
+  --vp-button-alt-hover-border: #c2c2c4;
+  --vp-button-alt-hover-bg: #e3e3e5;
+}
+
+.dark {
+  --vp-button-brand-text: black;
+  --vp-button-brand-hover-text: black;
+  --vp-button-alt-border: rgba(82, 82, 89, .68);
+  --vp-button-alt-bg: #323238;
+  --vp-button-alt-hover-bg: #222226;
 }
 
 /**

--- a/index.md
+++ b/index.md
@@ -14,10 +14,10 @@ hero:
   image:
     light:
       src: /icon_light.svg
-      alt: Vite PWA
+      alt: Vite PWA Logo
     dark:
       src: /icon_dark.svg
-      alt: Vite PWA
+      alt: Vite PWA Logo
   actions:
     - theme: brand
       text: Get Started

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-pwa-docs",
   "version": "0.16.4",
   "type": "module",
-  "packageManager": "pnpm@8.7.0",
+  "packageManager": "pnpm@8.7.1",
   "description": "Zero-config PWA for Vite Documentation",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "unocss": "^0.52.7",
     "unplugin-vue-components": "^0.25.1",
     "vite-plugin-pwa": "^0.16.4",
-    "vitepress": "1.0.0-rc.4",
+    "vitepress": "1.0.0-rc.10",
     "workbox-window": "^7.0.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ devDependencies:
     version: 0.2.0(vite-plugin-pwa@0.16.4)
   '@vitejs/plugin-vue':
     specifier: ^4.2.3
-    version: 4.2.3(vite@4.3.9)(vue@3.3.4)
+    version: 4.2.3(vite@4.4.9)(vue@3.3.4)
   eslint:
     specifier: ^8.42.0
     version: 8.42.0
@@ -48,16 +48,16 @@ devDependencies:
     version: 5.1.3
   unocss:
     specifier: ^0.52.7
-    version: 0.52.7(postcss@8.4.23)(rollup@2.79.1)(vite@4.3.9)
+    version: 0.52.7(postcss@8.4.28)(rollup@2.79.1)(vite@4.4.9)
   unplugin-vue-components:
     specifier: ^0.25.1
     version: 0.25.1(rollup@2.79.1)(vue@3.3.4)
   vite-plugin-pwa:
     specifier: ^0.16.4
-    version: 0.16.4(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
+    version: 0.16.4(vite@4.4.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
   vitepress:
-    specifier: 1.0.0-rc.4
-    version: 1.0.0-rc.4(search-insights@2.6.0)
+    specifier: 1.0.0-rc.10
+    version: 1.0.0-rc.10(search-insights@2.6.0)
   workbox-window:
     specifier: ^7.0.0
     version: 7.0.0
@@ -646,6 +646,7 @@ packages:
   /@babel/plugin-proposal-async-generator-functions@7.19.1(@babel/core@7.19.3):
     resolution: {integrity: sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -661,6 +662,7 @@ packages:
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -674,6 +676,7 @@ packages:
   /@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-+I3oIiNxrCpup3Gi8n5IGMwj0gOCAjcJUSQEcotNnCCPMEnixawOQ+KeJPlgfjzx+FKQ1QSyZOWe7wmoJp7vhw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-static-block instead.
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
@@ -688,6 +691,7 @@ packages:
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -699,6 +703,7 @@ packages:
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.19.3):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -710,6 +715,7 @@ packages:
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-json-strings instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -721,6 +727,7 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.18.9(@babel/core@7.19.3):
     resolution: {integrity: sha512-128YbMpjCrP35IOExw2Fq+x55LMP42DzhOhX2aNNIdI9avSWl2PI0yuBWarr3RYpZBSPtabfadkH2yeRiMD61Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -732,6 +739,7 @@ packages:
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -743,6 +751,7 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -754,6 +763,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread@7.18.9(@babel/core@7.19.3):
     resolution: {integrity: sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -768,6 +778,7 @@ packages:
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -779,6 +790,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.19.3):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -791,6 +803,7 @@ packages:
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -804,6 +817,7 @@ packages:
   /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -819,6 +833,7 @@ packages:
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.19.3):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -1517,28 +1532,10 @@ packages:
       - '@algolia/client-search'
     dev: true
 
-  /@esbuild/android-arm64@0.17.18:
-    resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.17.18:
-    resolution: {integrity: sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
@@ -1553,15 +1550,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.18:
-    resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-x64@0.18.20:
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -1571,28 +1559,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.18:
-    resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/darwin-arm64@0.18.20:
     resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.17.18:
-    resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -1607,28 +1577,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.18:
-    resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/freebsd-arm64@0.18.20:
     resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.17.18:
-    resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
@@ -1643,28 +1595,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.18:
-    resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-arm64@0.18.20:
     resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.17.18:
-    resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1679,28 +1613,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.18:
-    resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-ia32@0.18.20:
     resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.17.18:
-    resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1715,28 +1631,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.18:
-    resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-mips64el@0.18.20:
     resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.17.18:
-    resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1751,28 +1649,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.18:
-    resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-riscv64@0.18.20:
     resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.17.18:
-    resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -1787,29 +1667,11 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.18:
-    resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/linux-x64@0.18.20:
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.17.18:
-    resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
     requiresBuild: true
     dev: true
     optional: true
@@ -1823,29 +1685,11 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.18:
-    resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/openbsd-x64@0.18.20:
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.17.18:
-    resolution: {integrity: sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
     requiresBuild: true
     dev: true
     optional: true
@@ -1859,15 +1703,6 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.18:
-    resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-arm64@0.18.20:
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -1877,28 +1712,10 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.18:
-    resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/win32-ia32@0.18.20:
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
     cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.17.18:
-    resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -2312,12 +2129,12 @@ packages:
       eslint-visitor-keys: 3.4.1
     dev: true
 
-  /@unocss/astro@0.52.7(rollup@2.79.1)(vite@4.3.9):
+  /@unocss/astro@0.52.7(rollup@2.79.1)(vite@4.4.9):
     resolution: {integrity: sha512-jGm3sVB6AU3A1vXJskCdG2kUw1aRdg2fV60nILCBiRmj7SIlbMTXEHrz864AaleGVnxTiV7oGL4P1DfDJ3tQSA==}
     dependencies:
       '@unocss/core': 0.52.7
       '@unocss/reset': 0.52.7
-      '@unocss/vite': 0.52.7(rollup@2.79.1)(vite@4.3.9)
+      '@unocss/vite': 0.52.7(rollup@2.79.1)(vite@4.4.9)
     transitivePeerDependencies:
       - rollup
       - vite
@@ -2370,7 +2187,7 @@ packages:
       sirv: 2.0.3
     dev: true
 
-  /@unocss/postcss@0.52.7(postcss@8.4.23):
+  /@unocss/postcss@0.52.7(postcss@8.4.28):
     resolution: {integrity: sha512-0yG7K8ie9gky7Y/oD29Jzpe4l92IgRPB2Fo9a7g2f4dGlKOuih5S+NsH3EO4WODrawntISyxVXMHsIydze2vAw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2381,7 +2198,7 @@ packages:
       css-tree: 2.3.1
       fast-glob: 3.2.12
       magic-string: 0.30.0
-      postcss: 8.4.23
+      postcss: 8.4.28
     dev: true
 
   /@unocss/preset-attributify@0.52.7:
@@ -2481,7 +2298,7 @@ packages:
       '@unocss/core': 0.52.7
     dev: true
 
-  /@unocss/vite@0.52.7(rollup@2.79.1)(vite@4.3.9):
+  /@unocss/vite@0.52.7(rollup@2.79.1)(vite@4.4.9):
     resolution: {integrity: sha512-Hn1u6/uPP2q0s5gfwA7KQFtclviEUrEKnEa3l1kFJA3S/tHXYjwQkzbDQObQzolVAXyzIhf1cQ8e1tEMyHm1qg==}
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
@@ -2496,7 +2313,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.2.12
       magic-string: 0.30.0
-      vite: 4.3.9
+      vite: 4.4.9
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -2519,18 +2336,7 @@ packages:
     peerDependencies:
       vite-plugin-pwa: '>=0.16.3 <1'
     dependencies:
-      vite-plugin-pwa: 0.16.4(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
-    dev: true
-
-  /@vitejs/plugin-vue@4.2.3(vite@4.3.9)(vue@3.3.4):
-    resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^4.0.0
-      vue: ^3.2.25
-    dependencies:
-      vite: 4.3.9
-      vue: 3.3.4
+      vite-plugin-pwa: 0.16.4(vite@4.4.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
     dev: true
 
   /@vitejs/plugin-vue@4.2.3(vite@4.4.9)(vue@3.3.4):
@@ -2633,20 +2439,20 @@ packages:
       - vue
     dev: false
 
-  /@vueuse/core@10.3.0(vue@3.3.4):
-    resolution: {integrity: sha512-BEM5yxcFKb5btFjTSAFjTu5jmwoW66fyV9uJIP4wUXXU8aR5Hl44gndaaXp7dC5HSObmgbnR2RN+Un1p68Mf5Q==}
+  /@vueuse/core@10.4.1(vue@3.3.4):
+    resolution: {integrity: sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==}
     dependencies:
       '@types/web-bluetooth': 0.0.17
-      '@vueuse/metadata': 10.3.0
-      '@vueuse/shared': 10.3.0(vue@3.3.4)
+      '@vueuse/metadata': 10.4.1
+      '@vueuse/shared': 10.4.1(vue@3.3.4)
       vue-demi: 0.14.5(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
     dev: true
 
-  /@vueuse/integrations@10.3.0(focus-trap@7.5.2)(vue@3.3.4):
-    resolution: {integrity: sha512-Jgiv7oFyIgC6BxmDtiyG/fxyGysIds00YaY7sefwbhCZ2/tjEx1W/1WcsISSJPNI30in28+HC2J4uuU8184ekg==}
+  /@vueuse/integrations@10.4.1(focus-trap@7.5.2)(vue@3.3.4):
+    resolution: {integrity: sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==}
     peerDependencies:
       async-validator: '*'
       axios: '*'
@@ -2686,8 +2492,8 @@ packages:
       universal-cookie:
         optional: true
     dependencies:
-      '@vueuse/core': 10.3.0(vue@3.3.4)
-      '@vueuse/shared': 10.3.0(vue@3.3.4)
+      '@vueuse/core': 10.4.1(vue@3.3.4)
+      '@vueuse/shared': 10.4.1(vue@3.3.4)
       focus-trap: 7.5.2
       vue-demi: 0.14.5(vue@3.3.4)
     transitivePeerDependencies:
@@ -2699,8 +2505,8 @@ packages:
     resolution: {integrity: sha512-cM28HjDEw5FIrPE9rgSPFZvQ0ZYnOLAOr8hl1XM6tFl80U3WAR5ROdnAqiYybniwP5gt9MKKAJAqd/ab2aHkqg==}
     dev: false
 
-  /@vueuse/metadata@10.3.0:
-    resolution: {integrity: sha512-Ema3YhNOa4swDsV0V7CEY5JXvK19JI/o1szFO1iWxdFg3vhdFtCtSTP26PCvbUpnUtNHBY2wx5y3WDXND5Pvnw==}
+  /@vueuse/metadata@10.4.1:
+    resolution: {integrity: sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==}
     dev: true
 
   /@vueuse/shared@10.1.0(vue@3.3.4):
@@ -2712,8 +2518,8 @@ packages:
       - vue
     dev: false
 
-  /@vueuse/shared@10.3.0(vue@3.3.4):
-    resolution: {integrity: sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==}
+  /@vueuse/shared@10.4.1(vue@3.3.4):
+    resolution: {integrity: sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==}
     dependencies:
       vue-demi: 0.14.5(vue@3.3.4)
     transitivePeerDependencies:
@@ -2961,10 +2767,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /body-scroll-lock@4.0.0-beta.0:
-    resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
     dev: true
 
   /boolbase@1.0.0:
@@ -3529,36 +3331,6 @@ packages:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-    dev: true
-
-  /esbuild@0.17.18:
-    resolution: {integrity: sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.17.18
-      '@esbuild/android-arm64': 0.17.18
-      '@esbuild/android-x64': 0.17.18
-      '@esbuild/darwin-arm64': 0.17.18
-      '@esbuild/darwin-x64': 0.17.18
-      '@esbuild/freebsd-arm64': 0.17.18
-      '@esbuild/freebsd-x64': 0.17.18
-      '@esbuild/linux-arm': 0.17.18
-      '@esbuild/linux-arm64': 0.17.18
-      '@esbuild/linux-ia32': 0.17.18
-      '@esbuild/linux-loong64': 0.17.18
-      '@esbuild/linux-mips64el': 0.17.18
-      '@esbuild/linux-ppc64': 0.17.18
-      '@esbuild/linux-riscv64': 0.17.18
-      '@esbuild/linux-s390x': 0.17.18
-      '@esbuild/linux-x64': 0.17.18
-      '@esbuild/netbsd-x64': 0.17.18
-      '@esbuild/openbsd-x64': 0.17.18
-      '@esbuild/sunos-x64': 0.17.18
-      '@esbuild/win32-arm64': 0.17.18
-      '@esbuild/win32-ia32': 0.17.18
-      '@esbuild/win32-x64': 0.17.18
     dev: true
 
   /esbuild@0.18.20:
@@ -5595,14 +5367,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup@3.21.0:
-    resolution: {integrity: sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /rollup@3.28.0:
     resolution: {integrity: sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -6230,7 +5994,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unocss@0.52.7(postcss@8.4.23)(rollup@2.79.1)(vite@4.3.9):
+  /unocss@0.52.7(postcss@8.4.28)(rollup@2.79.1)(vite@4.4.9):
     resolution: {integrity: sha512-c35lqmzWqnQH0hW2IE1owac2qfGOvNAhrIrLV2+pNmc2MDWq8WMjIEuWo8G+OS5JqFQY3ZBlE61q2x/tHPlujQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -6239,11 +6003,11 @@ packages:
       '@unocss/webpack':
         optional: true
     dependencies:
-      '@unocss/astro': 0.52.7(rollup@2.79.1)(vite@4.3.9)
+      '@unocss/astro': 0.52.7(rollup@2.79.1)(vite@4.4.9)
       '@unocss/cli': 0.52.7(rollup@2.79.1)
       '@unocss/core': 0.52.7
       '@unocss/extractor-arbitrary-variants': 0.52.7
-      '@unocss/postcss': 0.52.7(postcss@8.4.23)
+      '@unocss/postcss': 0.52.7(postcss@8.4.28)
       '@unocss/preset-attributify': 0.52.7
       '@unocss/preset-icons': 0.52.7
       '@unocss/preset-mini': 0.52.7
@@ -6258,7 +6022,7 @@ packages:
       '@unocss/transformer-compile-class': 0.52.7
       '@unocss/transformer-directives': 0.52.7
       '@unocss/transformer-variant-group': 0.52.7
-      '@unocss/vite': 0.52.7(rollup@2.79.1)(vite@4.3.9)
+      '@unocss/vite': 0.52.7(rollup@2.79.1)(vite@4.4.9)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -6352,7 +6116,7 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-plugin-pwa@0.16.4(vite@4.3.9)(workbox-build@7.0.0)(workbox-window@7.0.0):
+  /vite-plugin-pwa@0.16.4(vite@4.4.9)(workbox-build@7.0.0)(workbox-window@7.0.0):
     resolution: {integrity: sha512-lmwHFIs9zI2H9bXJld/zVTbCqCQHZ9WrpyDMqosICDV0FVnCJwniX1NMDB79HGTIZzOQkY4gSZaVTJTw6maz/Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -6363,43 +6127,11 @@ packages:
       debug: 4.3.4
       fast-glob: 3.2.12
       pretty-bytes: 6.0.0
-      vite: 4.3.9
+      vite: 4.4.9
       workbox-build: 7.0.0
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /vite@4.3.9:
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.17.18
-      postcss: 8.4.23
-      rollup: 3.21.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.4.9:
@@ -6437,17 +6169,15 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitepress@1.0.0-rc.4(search-insights@2.6.0):
-    resolution: {integrity: sha512-JCQ89Bm6ECUTnyzyas3JENo00UDJeK8q1SUQyJYou+4Yz5BKEc/F3O21cu++DnUT2zXc0kvQ2Aj4BZCc/nioXQ==}
+  /vitepress@1.0.0-rc.10(search-insights@2.6.0):
+    resolution: {integrity: sha512-+MsahIWqq5WUEmj6MR4obcKYbT7im07jZPCQPdNJExkeOSbOAJ4xypSLx88x7rvtzWHhHc5aXbOhCRvGEGjFrw==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.5.2
       '@docsearch/js': 3.5.2(search-insights@2.6.0)
-      '@vitejs/plugin-vue': 4.2.3(vite@4.4.9)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
-      '@vueuse/core': 10.3.0(vue@3.3.4)
-      '@vueuse/integrations': 10.3.0(focus-trap@7.5.2)(vue@3.3.4)
-      body-scroll-lock: 4.0.0-beta.0
+      '@vueuse/core': 10.4.1(vue@3.3.4)
+      '@vueuse/integrations': 10.4.1(focus-trap@7.5.2)(vue@3.3.4)
       focus-trap: 7.5.2
       mark.js: 8.11.1
       minisearch: 6.1.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "@types/fs-extra",
       "node",
       "vite/client",
-      "vite-plugin-pwa/client",
+      "vite-plugin-pwa/vanillajs",
       "vitepress"
     ],
     "paths": {


### PR DESCRIPTION
This PR also changes the VP layout to add radial transition on theme switch: 
- changed main and vars styles with new VP variables
- tip, info, warning and info styles with current borders and colors: VP has changed them.

This PR also includes a few changes to the prompt for update PWA dialog (adds a small border, will be there after 2 updates) and also changing colors in Excalidraw SVG images on theme switch to meet WCAG AA:

![imagen](https://github.com/vite-pwa/docs/assets/6311119/113e3106-6280-452a-bb4d-5d0d771aab71)

![imagen](https://github.com/vite-pwa/docs/assets/6311119/f1183df6-6e38-4baa-a32b-8291d05346da)
