### PR TITLE
docs: include latest SvelteKit changes

### DIFF
--- a/.vitepress/components.d.ts
+++ b/.vitepress/components.d.ts
@@ -7,6 +7,7 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
+    BreakingChanges: typeof import('./theme/components/BreakingChanges.md')['default']
     CleanupOutdatedCaches: typeof import('./theme/components/CleanupOutdatedCaches.md')['default']
     ExamplesBehaviors: typeof import('./theme/components/ExamplesBehaviors.md')['default']
     ExamplesGenerateSW: typeof import('./theme/components/ExamplesGenerateSW.md')['default']

--- a/.vitepress/theme/components/BreakingChanges.md
+++ b/.vitepress/theme/components/BreakingChanges.md
@@ -1,0 +1,3 @@
+::: info
+Check [breaking changes page for more info](/guide/breaking-changes.html).
+:::

--- a/frameworks/astro.md
+++ b/frameworks/astro.md
@@ -5,6 +5,8 @@ outline: deep
 
 # Astro
 
+<BreakingChanges />
+
 ::: warning
 You will need to update your application to use Vite ^3.1.0 and latest `vite-plugin-pwa` 0.13.1+.
 :::

--- a/frameworks/nuxt.md
+++ b/frameworks/nuxt.md
@@ -6,6 +6,8 @@ outline: deep
 
 # Nuxt 3
 
+<BreakingChanges />
+
 ::: warning
 This PWA module can only be used with Vite.
 :::

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -4,6 +4,12 @@ title: SvelteKit | Frameworks
 
 # SvelteKit
 
+<BreakingChanges />
+
+::: info
+From version `v0.2.9`, `@vite-pwa/sveltekit` configures `dontCacheBustURLsMatching` in a similar way to how `vite-plugin-pwa` does, but using the Sveltkit's [appDir](https://kit.svelte.dev/docs/configuration#appdir) option (defaults to `_app`).
+:::
+
 ::: warning
 From version `v0.2.0`, `SvelteKitPWA` plugin requires SvelteKit 1.3.1 or above.
 

--- a/frameworks/vitepress.md
+++ b/frameworks/vitepress.md
@@ -5,6 +5,8 @@ outline: deep
 
 # VitePress
 
+<BreakingChanges />
+
 ::: warning
 We recommend you use the latest version of VitePress. The latest versions will also require you to update your application to use Vite ^3.1.0.
 :::


### PR DESCRIPTION
This PR also included a new info section in all meta frameworks with a link to breaking changes page