### PR TITLE
docs: update service-worker-without-pwa-capabilities.md

### DIFF
--- a/guide/service-worker-without-pwa-capabilities.md
+++ b/guide/service-worker-without-pwa-capabilities.md
@@ -32,7 +32,7 @@ VitePWA({
   injectRegister: false,
   manifest: false,
   injectManifest: {
-    injectionPoint: null,
+    injectionPoint: undefined,
   },
 })
 ```


### PR DESCRIPTION
`injectManifest.injectionPoint` was set to `null` in the example but according to the types, it can be `string | undefined`, so updated the value in the example to be `undefined`.

![image](https://github.com/vite-pwa/docs/assets/41461969/a64596a6-8ed5-4937-a032-87d54075535f)
