### PR TITLE
docs: point to main repo from navbar

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -354,7 +354,7 @@ export default withPwa(defineConfig({
     },
     socialLinks: [
       { icon: 'discord', link: 'https://discord.gg/uccDuWkScq' },
-      { icon: 'github', link: 'https://github.com/vite-pwa/docs' },
+      { icon: 'github', link: 'https://github.com/vite-pwa/vite-plugin-pwa' },
     ],
     footer: {
       message: 'Released under the MIT License.',


### PR DESCRIPTION
I think the navbar icon should point to main repo instead of the docs repo. People wanting to contribute to the docs can use the "Suggest changes to this page" link.