### PR TITLE
docs: include create-pwa v0.6.0 changes

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -52,7 +52,7 @@ const Guide: DefaultTheme.SidebarItem[] = [
     link: '/guide/development',
   },
   {
-    text: 'Scaffolding Your First Vite PWA Project <sup class="VPBadgeCustom tip">New</sup>',
+    text: 'Scaffolding Your First Vite PWA Project',
     link: '/guide/scaffolding',
   },
   {

--- a/guide/change-log.md
+++ b/guide/change-log.md
@@ -12,6 +12,13 @@ Please refer to the corresponding installation section:
 - [@vite-pwa/astro](https://github.com/vite-pwa/astro#-install)
 - [@vite-pwa/nuxt](https://github.com/vite-pwa/nuxt#-install)
 - [@vite-pwa/assets-generator](https://github.com/vite-pwa/assets-generator#-install)
+- [@vite-pwa/create-pwa](https://github.com/vite-pwa/create-pwa#-usage)
+
+## @vite-pwa/create-pwa <Badge type="tip" text="from v0.6.0" />
+
+From version `v0.6.0`, all the templates to use Vite 6, including also the latest frameworks changes.
+
+Use version `v0.5.0` for Vite 5 and previous versions of the frameworks.
 
 ## SvelteKit Single-page App Support <Badge type="tip" text="from v0.6.7" />
 

--- a/guide/scaffolding.md
+++ b/guide/scaffolding.md
@@ -1,3 +1,9 @@
-# Scaffolding Your First Vite PWA Project <Badge class="VPBadgeCustom tip" text="New" />
+# Scaffolding Your First Vite PWA Project
+
+::: tip
+From version `v0.6.0`, all the templates to use Vite 6, including also the latest frameworks changes.
+
+Use version `v0.5.0` for Vite 5 and previous versions of the frameworks.
+:::
 
 <ScaffoldingPWAProject />


### PR DESCRIPTION
This PR also includes:
- removes the `New` Bagde from the aside and from the page title
- inludes `create-pwa` link and changes in change log page